### PR TITLE
Extending the CORS filter to expose the location header.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.idea/
 target/
+*.iml
 *.sh

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ configuration is needed:
         <dependency>
             <groupId>com.airhacks</groupId>
             <artifactId>jaxrs-cors</artifactId>
-            <version>0.0.1</version>
+            <version>0.0.2</version>
             <scope>compile</scope>
         </dependency>
 ```

--- a/src/main/java/com/airhacks/cors/CorsResponseFilter.java
+++ b/src/main/java/com/airhacks/cors/CorsResponseFilter.java
@@ -19,13 +19,13 @@ package com.airhacks.cors;
  * limitations under the License.
  * #L%
  */
-import java.io.IOException;
-import java.util.List;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.util.List;
 
 /**
  * See http://www.w3.org/TR/cors/
@@ -38,26 +38,33 @@ public class CorsResponseFilter implements ContainerResponseFilter {
     public static final String ALLOWED_METHODS = "GET, POST, PUT, DELETE, OPTIONS, HEAD";
     public final static int MAX_AGE = 42 * 60 * 60;
     public final static String DEFAULT_ALLOWED_HEADERS = "origin,accept,content-type";
+    public final static String DEFAULT_EXPOSED_HEADERS = "location";
 
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
         final MultivaluedMap<String, Object> headers = responseContext.getHeaders();
         headers.add("Access-Control-Allow-Origin", "*");
-        headers.add("Access-Control-Allow-Headers", getRequestedHeaders(requestContext));
+        headers.add("Access-Control-Allow-Headers", getRequestedAllowedHeaders(requestContext));
+        headers.add("Access-Control-Expose-Headers", getRequestedExposedHeaders(requestContext));
         headers.add("Access-Control-Allow-Credentials", "true");
         headers.add("Access-Control-Allow-Methods", ALLOWED_METHODS);
         headers.add("Access-Control-Max-Age", MAX_AGE);
         headers.add("x-responded-by", "cors-response-filter");
     }
 
-    String getRequestedHeaders(ContainerRequestContext responseContext) {
-        List<String> headers = responseContext.getHeaders().get("Access-Control-Request-Headers");
-        return createHeaderList(headers);
+    String getRequestedAllowedHeaders(ContainerRequestContext responseContext) {
+        List<String> headers = responseContext.getHeaders().get("Access-Control-Allow-Headers");
+        return createHeaderList(headers, DEFAULT_ALLOWED_HEADERS);
     }
 
-    String createHeaderList(List<String> headers) {
+    String getRequestedExposedHeaders(ContainerRequestContext responseContext) {
+        List<String> headers = responseContext.getHeaders().get("Access-Control-Expose-Headers");
+        return createHeaderList(headers, DEFAULT_ALLOWED_HEADERS);
+    }
+
+    String createHeaderList(List<String> headers, String defaultHeaders) {
         if (headers == null || headers.isEmpty()) {
-            return DEFAULT_ALLOWED_HEADERS;
+            return defaultHeaders;
         }
         StringBuilder retVal = new StringBuilder();
         for (int i = 0; i < headers.size(); i++) {
@@ -65,7 +72,7 @@ public class CorsResponseFilter implements ContainerResponseFilter {
             retVal.append(header);
             retVal.append(',');
         }
-        retVal.append(DEFAULT_ALLOWED_HEADERS);
+        retVal.append(defaultHeaders);
         return retVal.toString();
     }
 

--- a/src/test/java/com/airhacks/cors/CorsResponseFilterTest.java
+++ b/src/test/java/com/airhacks/cors/CorsResponseFilterTest.java
@@ -19,12 +19,16 @@ package com.airhacks.cors;
  * limitations under the License.
  * #L%
  */
-import java.util.ArrayList;
-import java.util.List;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.airhacks.cors.CorsResponseFilter.DEFAULT_ALLOWED_HEADERS;
+import static com.airhacks.cors.CorsResponseFilter.DEFAULT_EXPOSED_HEADERS;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 /**
  *
@@ -32,7 +36,7 @@ import org.junit.Test;
  */
 public class CorsResponseFilterTest {
 
-    CorsResponseFilter cut;
+    private CorsResponseFilter cut;
 
     @Before
     public void init() {
@@ -40,29 +44,56 @@ public class CorsResponseFilterTest {
     }
 
     @Test
-    public void noHeaders() {
+    public void noAllowedHeaders() {
         List<String> headers = null;
-        String expected = CorsResponseFilter.DEFAULT_ALLOWED_HEADERS;
-        String actual = cut.createHeaderList(headers);
+        String expected = DEFAULT_ALLOWED_HEADERS;
+        String actual = cut.createHeaderList(headers, DEFAULT_ALLOWED_HEADERS);
         assertThat(actual, is(expected));
     }
 
     @Test
-    public void multipleHeaders() {
+    public void multipleAllowedHeaders() {
         List<String> headers = new ArrayList<>();
         headers.add("java");
         headers.add("duke");
-        String expected = "java,duke," + CorsResponseFilter.DEFAULT_ALLOWED_HEADERS;
-        String actual = cut.createHeaderList(headers);
+        String expected = "java,duke," + DEFAULT_ALLOWED_HEADERS;
+        String actual = cut.createHeaderList(headers, DEFAULT_ALLOWED_HEADERS);
         assertThat(actual, is(expected));
     }
 
     @Test
-    public void singleHeader() {
+    public void singleAllowedHeader() {
         List<String> headers = new ArrayList<>();
         headers.add("java");
-        String expected = "java," + CorsResponseFilter.DEFAULT_ALLOWED_HEADERS;
-        String actual = cut.createHeaderList(headers);
+        String expected = "java," + DEFAULT_ALLOWED_HEADERS;
+        String actual = cut.createHeaderList(headers, DEFAULT_ALLOWED_HEADERS);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void noExposedHeaders() {
+        List<String> headers = null;
+        String expected = DEFAULT_EXPOSED_HEADERS;
+        String actual = cut.createHeaderList(headers, DEFAULT_EXPOSED_HEADERS);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void multipleExposedHeaders() {
+        List<String> headers = new ArrayList<>();
+        headers.add("java");
+        headers.add("duke");
+        String expected = "java,duke," + DEFAULT_EXPOSED_HEADERS;
+        String actual = cut.createHeaderList(headers, DEFAULT_EXPOSED_HEADERS);
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void singleExposedHeader() {
+        List<String> headers = new ArrayList<>();
+        headers.add("java");
+        String expected = "java," + DEFAULT_EXPOSED_HEADERS;
+        String actual = cut.createHeaderList(headers, DEFAULT_EXPOSED_HEADERS);
         assertThat(actual, is(expected));
     }
 


### PR DESCRIPTION
The location header is often used in RESTful APIs to get the URL of a new created resource (POST).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/adambien/cors/1)
<!-- Reviewable:end -->
